### PR TITLE
fix list-all

### DIFF
--- a/bin/list-all
+++ b/bin/list-all
@@ -14,5 +14,5 @@ function sort_versions() {
 }
 
 # Fetch all tag names, and get only second column. Then remove all unnecesary characters.
-versions=$(eval $cmd | grep -oE "tag_name\":\s*\".{1,15}\"," | sed 's/tag_name\":\s*\"//;s/v//;s/\",//' | sort_versions)
+versions=$(eval "$cmd" | grep -oE 'tag_name": *"[^"]*?",' | sed -e 's|^tag_name" *: *"||' -e 's|",||' | sort_versions)
 echo $versions


### PR DESCRIPTION
Before:
```
❯ asdf list-all kops
"1.8.1.z
"1.9.0.alpha.1.z
"1.9.0.beta.1.z
"1.9.0.alpha.2.z
"1.9.0.beta.2.z
"1.9.0.alpha.3.z
"1.9.0.z
"1.9.1.z
"1.9.2.z
"1.10.0.alpha.1.z
"1.10.0.beta.1.z
"1.10.0.z
"1.10.1.z
"1.11.0.alpha.1.z
"1.11.0.beta.1.z
"1.11.0.z
"1.11.1.z
"1.12.0.beta.1.z
"1.12.0.alpha.2.z
"1.12.0.beta.2.z
"1.12.0.alpha.3.z
"1.12.0.z
"1.12.1.z
"1.12.2.z
"1.13.0.alpha.1.z
"1.13.0.beta.1.z
"1.13.0.beta.2.z
"1.14.0.alpha.1.z
"1.14.0.alpha.2.z
"1.14.0.alpha.3.z
```


After:
```
❯ asdf list-all kops
1.8.1
1.9.0-alpha.1
1.9.0-beta.1
1.9.0-alpha.2
1.9.0-beta.2
1.9.0-alpha.3
1.9.0
1.9.1
1.9.2
1.10.0-alpha.1
1.10.0-beta.1
1.10.0
1.10.1
1.11.0-alpha.1
1.11.0-beta.1
1.11.0
1.11.1
1.12.0-beta.1
1.12.0-alpha.2
1.12.0-beta.2
1.12.0-alpha.3
1.12.0
1.12.1
1.12.2
1.13.0-alpha.1
1.13.0-beta.1
1.13.0-beta.2
1.14.0-alpha.1
1.14.0-alpha.2
1.14.0-alpha.3
```