### PR TITLE
Handle missing versions

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -23,9 +23,12 @@ install_kops() {
   local download_path="$tmp_download_dir/$(get_filename $platform)"
 
   echo "Downloading kops from ${download_url} to ${binary_path}"
-  curl -Lo $binary_path $download_url
-
-  chmod +x ${binary_path}
+  if curl -Lfs "${download_url}" -o "${binary_path}"; then
+    chmod +x "${binary_path}"
+  else
+    echo "Error: kops ${version} not found. Run 'asdf list-all kops' for available versions." >&2
+    exit 1
+  fi
 }
 
 get_filename() {


### PR DESCRIPTION
Fixes https://github.com/Antiarchitect/asdf-kops/issues/4

`kops` has changed to prefix versions with `v` now. Instead of failing silently and downloading garbage, error to the user and recommend listing all versions to find the one they expect.

I felt this was better than automatically trying to prepend `v${version}` if the initial call fails. Seem sane or do you have a preference?