### PR TITLE
Fetch the maximum number of releases from GitHub

### DIFF
--- a/bin/list-all
+++ b/bin/list-all
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-releases_path=https://api.github.com/repos/kubernetes/kops/releases
+releases_path=https://api.github.com/repos/kubernetes/kops/releases\?per_page=100
 cmd="curl -s"
 if [ -n "$GITHUB_API_TOKEN" ]; then
   cmd="$cmd -H 'Authorization: token $GITHUB_API_TOKEN'"


### PR DESCRIPTION
This modifies the API call to GitHub to fetch the 100 latest releases, instead of the default 30.

We still depend on an older version of Kops, and this change enables us to use asdf to handle the version.