### PR TITLE
Add support for arm64 architecture

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -7,7 +7,7 @@ install_kops() {
   local install_type=$1
   local version=$2
   local install_path=$3
-  local platform="$(uname | tr '[:upper:]' '[:lower:]')-amd64"
+  local platform="$(uname | tr '[:upper:]' '[:lower:]')-$(get_arch)"
   local bin_install_path="$install_path/bin"
   local binary_path="$bin_install_path/kops"
   local download_url=$(get_download_url $version $platform)
@@ -29,6 +29,15 @@ install_kops() {
     echo "Error: kops ${version} not found. Run 'asdf list-all kops' for available versions." >&2
     exit 1
   fi
+}
+
+get_arch() {
+  ARCH=$(uname -m)
+  case $ARCH in
+    x86_64) ARCH="amd64";;
+    arm64|aarch64) ARCH="arm64";;
+  esac
+  echo "$ARCH"
 }
 
 get_filename() {


### PR DESCRIPTION
Hi, just like Antiarchitect/asdf-helm#10 I added the `arm64` support.

Currently `kops` releases `arm64` client binaries for:
- `linux/arm64` (>= `v1.19.0` [refs](https://github.com/kubernetes/kops/blob/v1.19.0/.shipbot.yaml))
- `darwin/arm64` (>= `v1.22.0` [refs](https://github.com/kubernetes/kops/blob/v1.22.0/.shipbot.yaml))

### Known issue
If Apple M1 users want to install the `kops` before `v1.22.0`, they have to run `asdf` with `arch`:

```
arch -x86_64 asdf install kops v1.21.6
```