### PR TITLE
Fix kops latest stable

### DIFF
--- a/bin/latest-stable
+++ b/bin/latest-stable
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+get_latest_release="curl -s https://api.github.com/repos/kubernetes/kOps/releases/latest"
+if which jq >/dev/null 2>&1; then
+    $get_latest_release | jq -r .tag_name
+else
+    $get_latest_release | grep tag_name | cut -f 2  -d ":" | cut -f "2" -d '"'
+fi

--- a/bin/latest-stable
+++ b/bin/latest-stable
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 
-get_latest_release="curl -s https://api.github.com/repos/kubernetes/kOps/releases/latest"
+if [ -n "$GITHUB_API_TOKEN" ]; then
+  auth="'Authorization: token $GITHUB_API_TOKEN'"
+fi
+
+get_latest_release="curl -s $auth https://api.github.com/repos/kubernetes/kOps/releases/latest"
 if which jq >/dev/null 2>&1; then
     $get_latest_release | jq -r .tag_name
 else


### PR DESCRIPTION
Currently, when running `asdf kops latest` i get the following output: `1.15.0`.

Now I'm not sure why it is doing like this, according to [the optional scripts docs](http://asdf-vm.com/plugins/create.html#optional-scripts), it performs some filtering on the list-all method before taking the last element in the list.
Maybe because `1.15.0` is the latest version that does not starts with a `v`?

This PR adds the `latest-stable` bin that retrieve the latest stable version directly from the Github releases.