### PR TITLE
remove github api token header

### DIFF
--- a/bin/list-all
+++ b/bin/list-all
@@ -1,11 +1,7 @@
 #!/usr/bin/env bash
 
 releases_path="https://api.github.com/repos/kubernetes/kops/releases?per_page=100"
-cmd="curl -s"
-if [ -n "$GITHUB_API_TOKEN" ]; then
-  cmd="$cmd -H 'Authorization: token $GITHUB_API_TOKEN'"
-fi
-cmd="$cmd $releases_path"
+cmd="curl -s $releases_path"
 
 # stolen from https://github.com/rbenv/ruby-build/pull/631/files#diff-fdcfb8a18714b33b07529b7d02b54f1dR942
 function sort_versions() {


### PR DESCRIPTION
Using the `asdf list all kops` command is not working as the github api gives a bad response back when providing a api token with the request. This auth header is not needed for sending a request to this endpoint.
With this change we remove that error and the `list all` function works correctly.